### PR TITLE
Add LAN accessible stats app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Baseball Stats Server
+
+This project provides a simple Express and Socket.IO server to share baseball statistics over your local network.
+
+## Features
+
+- Loads player statistics from `stats.json` at startup.
+- Supports updating statistics via `POST /stats` and broadcasts changes with Socket.IO.
+- Exports current statistics with `GET /stats/export`.
+- Serves a small web page showing the stats in real time.
+- The server listens on `0.0.0.0` so it can be accessed from other devices on the same LAN.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Edit `stats.json` with your players and their `AVG`, `CP` (carreras producidas) and `HR` values.
+3. Start the server:
+   ```bash
+   npm start
+   ```
+4. Open a browser on another device in your LAN and navigate to `http://<server-ip>:3000` to view the statistics.
+
+## Updating Stats
+
+Send a `POST` request with a JSON body to `http://<server-ip>:3000/stats` to update all statistics. The server saves changes back to `stats.json`.

--- a/public/index.html
+++ b/public/index.html
@@ -7,8 +7,18 @@
   <script src="script.js" defer></script>
 </head>
 <body>
-  <h1>Estadísticas de la Liga Estatal</h1>
-  <pre id="stats"></pre>
+  <h1>Estadísticas de Jugadores</h1>
+  <table id="statsTable" border="1">
+    <thead>
+      <tr>
+        <th>Nombre</th>
+        <th>AVG</th>
+        <th>CP</th>
+        <th>HR</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
   <button id="download">Descargar JSON</button>
 </body>
 </html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,9 +1,16 @@
 const socket = io();
-const statsPre = document.getElementById('stats');
+const tableBody = document.querySelector('#statsTable tbody');
 const downloadBtn = document.getElementById('download');
 
 socket.on('statsUpdated', data => {
-  statsPre.textContent = JSON.stringify(data, null, 2);
+  tableBody.innerHTML = '';
+  if (data.players) {
+    data.players.forEach(p => {
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${p.name}</td><td>${p.AVG}</td><td>${p.CP}</td><td>${p.HR}</td>`;
+      tableBody.appendChild(row);
+    });
+  }
 });
 
 downloadBtn.addEventListener('click', () => {

--- a/stats.json
+++ b/stats.json
@@ -1,0 +1,6 @@
+{
+  "players": [
+    {"name": "Juan Perez", "AVG": 0.305, "CP": 45, "HR": 12},
+    {"name": "Luis Gomez", "AVG": 0.289, "CP": 37, "HR": 8}
+  ]
+}


### PR DESCRIPTION
## Summary
- support loading/saving stats from `stats.json`
- show player stats table in the web UI
- allow connections from other machines on the LAN
- document usage in `README.md`

## Testing
- `npm test`
- `npm start` (fails without dependencies)
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6840c8532c9c83268e1ed6268e4c0eb0